### PR TITLE
Fix the executable name

### DIFF
--- a/gitlab-ci-cd/.gitlab-ci.yml
+++ b/gitlab-ci-cd/.gitlab-ci.yml
@@ -4,8 +4,8 @@ artillery:
     entrypoint: [""]
   script: |
     mkdir reports
-    /home/node/artillery/bin/artillery run --output reports/report.json tests/performance/socket-io.yml
-    /home/node/artillery/bin/artillery report --output reports/report.html reports/report.json
+    /home/node/artillery/bin/run run --output reports/report.json tests/performance/socket-io.yml
+    /home/node/artillery/bin/run report --output reports/report.html reports/report.json
   artifacts:
     paths:
       - reports


### PR DESCRIPTION
[This](https://github.com/artilleryio/artillery/pull/1345) changed the name of the executable such that the current CI fails as `/home/node/artillery/bin/artillery` no longer exists. This should fix it.